### PR TITLE
SLING-9389: Distribution Event Properties enhanced for holding queue item creation time stamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <artifactId>jsr305</artifactId>
             <version>2.0.0</version>
         </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     <!-- ======================================================================= -->
     <parent>
         <groupId>org.apache.sling</groupId>
-        <artifactId>sling</artifactId>
-        <version>26</version>
+        <artifactId>sling-bundle-parent</artifactId>
+        <version>38</version>
         <relativePath />
     </parent>
 
@@ -34,7 +34,6 @@
     <!-- ======================================================================= -->
     <artifactId>org.apache.sling.distribution.api</artifactId>
     <version>0.4.1-SNAPSHOT</version>
-    <packaging>bundle</packaging>
 
     <name>Apache Sling Distribution API</name>
     <description>
@@ -54,22 +53,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>maven-sling-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>org.apache.sling.distribution.api</Bundle-SymbolicName>
-                    </instructions>
-                </configuration>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -93,27 +78,32 @@
         <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
-            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>16.0.2</version>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/org/apache/sling/distribution/DistributionRequest.java
+++ b/src/main/java/org/apache/sling/distribution/DistributionRequest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
+import javax.annotation.Nonnull;
 
-import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * A {@link org.apache.sling.distribution.DistributionRequest} represents the need from the caller to have
@@ -35,7 +35,7 @@ public interface DistributionRequest {
      *
      * @return the type of the request as a {@link DistributionRequestType}
      */
-    @NotNull
+    @Nonnull
     DistributionRequestType getRequestType();
 
     /**
@@ -43,7 +43,7 @@ public interface DistributionRequest {
      *
      * @return an array of paths
      */
-    @NotNull
+    @Nonnull
     public String[] getPaths();
 
     /**
@@ -52,7 +52,7 @@ public interface DistributionRequest {
      * @param path the path to be checked
      * @return <code>true</code> if the paths are deep
      */
-    public boolean isDeep(@NotNull String path);
+    public boolean isDeep(String path);
 
 
 
@@ -65,6 +65,6 @@ public interface DistributionRequest {
      * @param path the path to get applicable filters for
      * @return an array of filters
      */
-    @NotNull
+    @Nonnull
     public String[] getFilters(String path);
 }

--- a/src/main/java/org/apache/sling/distribution/DistributionRequestState.java
+++ b/src/main/java/org/apache/sling/distribution/DistributionRequestState.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/distribution/DistributionRequestType.java
+++ b/src/main/java/org/apache/sling/distribution/DistributionRequestType.java
@@ -18,9 +18,9 @@
  */
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
+import javax.annotation.Nullable;
 
-import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * <p>
@@ -66,7 +66,7 @@ public enum DistributionRequestType {
      * @return the type or {@code null}
      */
     @Nullable
-    public static DistributionRequestType fromName(String n) {
+    public static DistributionRequestType fromName(@Nullable String n) {
         if (n == null) {
             return null;
         }

--- a/src/main/java/org/apache/sling/distribution/DistributionResponse.java
+++ b/src/main/java/org/apache/sling/distribution/DistributionResponse.java
@@ -18,10 +18,10 @@
  */
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * A {@link org.apache.sling.distribution.DistributionResponse} represents the outcome of a
@@ -47,7 +47,7 @@ public interface DistributionResponse {
      *
      * @return the state of the associated request
      */
-    @NotNull
+    @Nonnull
     DistributionRequestState getState();
 
     /**

--- a/src/main/java/org/apache/sling/distribution/Distributor.java
+++ b/src/main/java/org/apache/sling/distribution/Distributor.java
@@ -19,9 +19,10 @@
 
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
+import javax.annotation.Nonnull;
+
 import org.apache.sling.api.resource.ResourceResolver;
-import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * <p>
@@ -49,9 +50,9 @@ public interface Distributor {
      * @param resourceResolver    the resource resolver used for authorizing the request,
      * @return a {@link org.apache.sling.distribution.DistributionResponse}
      */
-    @NotNull
-    DistributionResponse distribute(@NotNull String agentName, @NotNull ResourceResolver resourceResolver,
-                                    @NotNull DistributionRequest distributionRequest);
+    @Nonnull
+    DistributionResponse distribute(String agentName, ResourceResolver resourceResolver,
+                                    DistributionRequest distributionRequest);
 
 
 }

--- a/src/main/java/org/apache/sling/distribution/SimpleDistributionRequest.java
+++ b/src/main/java/org/apache/sling/distribution/SimpleDistributionRequest.java
@@ -18,14 +18,15 @@
  */
 package org.apache.sling.distribution;
 
-import aQute.bnd.annotation.ProviderType;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * A {@link SimpleDistributionRequest} is a {@link DistributionRequest} where all paths are either "deep" or "shallow".
@@ -45,7 +46,7 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      * @param isDeep is <code>true</code> if all paths are "deep" and is <code>false</code> if all paths are "shallow"
      * @param paths the array of paths to be distributed
      */
-    public SimpleDistributionRequest(@NotNull DistributionRequestType requestType, boolean isDeep, @NotNull String... paths) {
+    public SimpleDistributionRequest(DistributionRequestType requestType, boolean isDeep, String... paths) {
         this(requestType, paths, isDeep? new HashSet<String>(Arrays.asList(paths)) : new HashSet<String>());
     }
 
@@ -54,7 +55,7 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      * @param requestType the request type
      * @param paths the array of paths to be distributed
      */
-    public SimpleDistributionRequest(@NotNull DistributionRequestType requestType, @NotNull String... paths) {
+    public SimpleDistributionRequest(DistributionRequestType requestType, String... paths) {
         this(requestType, false, paths);
     }
 
@@ -65,7 +66,7 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      * @param paths the array of paths to be distributed
      * @param deepPaths the set of paths that are to be distributed in depth (with all their children)
      */
-    public SimpleDistributionRequest(@NotNull DistributionRequestType requestType, @NotNull String[] paths, @NotNull Set<String> deepPaths) {
+    public SimpleDistributionRequest(DistributionRequestType requestType, String[] paths, Set<String> deepPaths) {
         this(requestType, paths, deepPaths, new HashMap<String, String[]>());
     }
 
@@ -77,7 +78,7 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      * @param deepPaths the set of paths that are to be distributed in depth (with all their children)
      * @param pathFilters the filters applicable for each path
      */
-    public SimpleDistributionRequest(@NotNull DistributionRequestType requestType, @NotNull String[] paths, @NotNull Set<String> deepPaths, @NotNull Map<String, String[]> pathFilters) {
+    public SimpleDistributionRequest(DistributionRequestType requestType, String[] paths, Set<String> deepPaths, Map<String, String[]> pathFilters) {
         this.requestType = requestType;
         this.paths = paths;
         this.deepPaths = deepPaths;
@@ -89,7 +90,7 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      *
      * @return the type of the request as a {@link DistributionRequestType}
      */
-    @NotNull
+    @Nonnull
     public DistributionRequestType getRequestType() {
         return requestType;
     }
@@ -108,11 +109,11 @@ public final class SimpleDistributionRequest implements DistributionRequest {
      * Returns whether the a path is covering the entire subtree (deep) or just the specified nodes (shallow)
      * @return <code>true</code> if the path is deep
      */
-    public boolean isDeep(@NotNull String path) {
+    public boolean isDeep(String path) {
         return deepPaths.contains(path);
     }
 
-    @NotNull
+    @Nonnull
     public String[] getFilters(String path) {
         String[] filters = pathFilters.get(path);
         return filters != null ? filters : new String[0];

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEvent.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.event;
+
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_COMPONENT_KIND;
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_COMPONENT_NAME;
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_PACKAGE_ID;
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_PATHS;
+import static org.apache.sling.distribution.event.DistributionEventProperties.DISTRIBUTION_TYPE;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.osgi.service.event.Event;
+
+public class DistributionEvent {
+
+    private final String packageId;
+    private final String componentName;
+    private final String componentKind;
+    private final String distType;
+    private final String[] distPaths;
+
+    public DistributionEvent(
+            String packageId,
+            String componentName,
+            String componentKind,
+            String distType,
+            String[] distPaths) {
+        this.packageId = packageId;
+        this.componentName = componentName;
+        this.componentKind = componentKind;
+        this.distType = distType;
+        this.distPaths = distPaths;
+    }
+
+    public String getPackageId() {
+        return packageId;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public String getComponentKind() {
+        return componentKind;
+    }
+
+    public String getDistType() {
+        return distType;
+    }
+
+    public String[] getDistPaths() {
+        return distPaths;
+    }
+
+    public Event toEvent(String topic) {
+        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put(DISTRIBUTION_PACKAGE_ID, packageId);
+        props.put(DISTRIBUTION_COMPONENT_NAME, componentName);
+        props.put(DISTRIBUTION_COMPONENT_KIND, componentKind);
+        props.put(DISTRIBUTION_TYPE, distType);
+        props.put(DISTRIBUTION_PATHS, distPaths);
+        return new Event(topic, props);
+    }
+
+    public static DistributionEvent fromEvent(Event event) {
+        return new DistributionEvent(
+                event.getProperty(DISTRIBUTION_PACKAGE_ID).toString(), 
+                event.getProperty(DISTRIBUTION_COMPONENT_NAME).toString(),
+                event.getProperty(DISTRIBUTION_COMPONENT_KIND).toString(),
+                event.getProperty(DISTRIBUTION_TYPE).toString(),
+                (String[])event.getProperty(DISTRIBUTION_PATHS));
+    }
+}

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -47,4 +47,9 @@ public interface DistributionEventProperties {
      * property containing the type of the distribution paths
      */
     String DISTRIBUTION_PATHS= "distribution.paths";
+
+    /**
+     * property containing the time when an item was enqueued for distribution
+     */
+    String DISTRIBUTION_ENQUEUE_TIMESTAMP = "distribution.enqueue.timestamp";
 }

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -49,7 +49,7 @@ public interface DistributionEventProperties {
     String DISTRIBUTION_PATHS= "distribution.paths";
 
     /**
-     * property containing the time when an item was enqueued for distribution
+     * property containing the time when an item was created and enqueued for distribution
      */
     String DISTRIBUTION_ENQUEUE_TIMESTAMP = "distribution.enqueue.timestamp";
 }

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -47,4 +47,9 @@ public interface DistributionEventProperties {
      * property containing the type of the distribution paths
      */
     String DISTRIBUTION_PATHS= "distribution.paths";
+    
+    /**
+     * Package id
+     */
+    String DISTRIBUTION_PACKAGE_ID = "distribution.package.id";
 }

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -53,7 +53,7 @@ public interface DistributionEventProperties {
     String DISTRIBUTION_PACKAGE_ID = "distribution.package.id";
 
     /**
-     * property containing the time when an item was enqueued for distribution
+     * property containing the time when an item was created and enqueued for distribution
      */
     String DISTRIBUTION_ENQUEUE_TIMESTAMP = "distribution.enqueue.timestamp";
 }

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -18,8 +18,7 @@
  */
 package org.apache.sling.distribution.event;
 
-
-import aQute.bnd.annotation.ProviderType;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * an interface containing of the possible properties of events related to distribution

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -51,4 +51,9 @@ public interface DistributionEventProperties {
      * Package id
      */
     String DISTRIBUTION_PACKAGE_ID = "distribution.package.id";
+
+    /**
+     * property containing the time when an item was enqueued for distribution
+     */
+    String DISTRIBUTION_ENQUEUE_TIMESTAMP = "distribution.enqueue.timestamp";
 }

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.distribution.event;
 
-import aQute.bnd.annotation.ProviderType;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * an interface containing of the possible topics of events related to distribution

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
@@ -29,27 +29,28 @@ public interface DistributionEventTopics {
     String EVENT_BASE = "org/apache/sling/distribution";
 
     /**
-     * event for package created
+     * Event raised after the successful creation of a content package.
      */
     String AGENT_PACKAGE_CREATED = EVENT_BASE + "/agent/package/created";
 
     /**
-     * event for package queued
+     * Event raised after successfully storing a content package to the distribution queues.
      */
     String AGENT_PACKAGE_QUEUED = EVENT_BASE + "/agent/package/queued";
 
     /**
-     * event for package distributed
+     * Event raised after successfully distributing a content package from a distribution queue.
      */
     String AGENT_PACKAGE_DISTRIBUTED = EVENT_BASE + "/agent/package/distributed";
 
     /**
-     * event for package dropped
+     * Event raised when a content package could not be distributed
+     * and was removed from a distribution queue.
      */
     String AGENT_PACKAGE_DROPPED = EVENT_BASE + "/agent/package/dropped";
 
     /**
-     * event for package imported
+     * Event raised after successfully importing a content package.
      */
     String IMPORTER_PACKAGE_IMPORTED = EVENT_BASE + "/importer/package/imported";
 }

--- a/src/main/java/org/apache/sling/distribution/event/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/event/package-info.java
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-@Version("0.3.0")
+@org.osgi.annotation.versioning.Version("0.3.0")
 package org.apache.sling.distribution.event;
-
-import aQute.bnd.annotation.Version;
 

--- a/src/main/java/org/apache/sling/distribution/event/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/event/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("0.2.0")
+@Version("0.3.0")
 package org.apache.sling.distribution.event;
 
 import aQute.bnd.annotation.Version;

--- a/src/main/java/org/apache/sling/distribution/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/package-info.java
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-@Version("0.3.1")
+@javax.annotation.ParametersAreNonnullByDefault
+@org.osgi.annotation.versioning.Version("0.3.1")
 package org.apache.sling.distribution;
-
-import aQute.bnd.annotation.Version;
-

--- a/src/main/java/org/apache/sling/distribution/transport/DistributionTransportSecret.java
+++ b/src/main/java/org/apache/sling/distribution/transport/DistributionTransportSecret.java
@@ -19,9 +19,10 @@
 package org.apache.sling.distribution.transport;
 
 import java.util.Map;
-import aQute.bnd.annotation.ConsumerType;
 
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
+
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/distribution/transport/DistributionTransportSecretProvider.java
+++ b/src/main/java/org/apache/sling/distribution/transport/DistributionTransportSecretProvider.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.distribution.transport;
 
-import aQute.bnd.annotation.ConsumerType;
-
 import java.net.URI;
 
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
+
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * <p>

--- a/src/main/java/org/apache/sling/distribution/transport/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/transport/package-info.java
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-@Version("0.1.1")
+@javax.annotation.ParametersAreNonnullByDefault
+@org.osgi.annotation.versioning.Version("0.1.1")
 package org.apache.sling.distribution.transport;
 
-import aQute.bnd.annotation.Version;
 

--- a/src/test/java/org/apache/sling/distribution/event/DistributionEventTest.java
+++ b/src/test/java/org/apache/sling/distribution/event/DistributionEventTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.event;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.service.event.Event;
+
+public class DistributionEventTest {
+
+    private static final String PATH1 = "/test";
+    private static final String DIST_TYPE = "ADD";
+    private static final String NAME = "myagent";
+    private static final String KIND = "agent";
+    private static final String PKG_ID = "pkg-1";
+    private DistributionEvent event;
+
+    @Before
+    public void before() {
+        event = new DistributionEvent(PKG_ID, NAME, KIND, DIST_TYPE, new String[] {PATH1});
+    }
+
+    @Test
+    public void testToEvent() {
+        Event osgiEvent = event.toEvent(DistributionEventTopics.AGENT_PACKAGE_CREATED);
+        assertThat(osgiEvent.getTopic(), equalTo(DistributionEventTopics.AGENT_PACKAGE_CREATED));
+        assertThat((String)osgiEvent.getProperty(DistributionEventProperties.DISTRIBUTION_PACKAGE_ID), equalTo(PKG_ID));
+        assertThat((String)osgiEvent.getProperty(DistributionEventProperties.DISTRIBUTION_COMPONENT_KIND), equalTo(KIND));
+        assertThat((String)osgiEvent.getProperty(DistributionEventProperties.DISTRIBUTION_COMPONENT_NAME), equalTo(NAME));
+        assertThat((String)osgiEvent.getProperty(DistributionEventProperties.DISTRIBUTION_TYPE), equalTo(DIST_TYPE));
+        String[] paths = (String[])(osgiEvent.getProperty(DistributionEventProperties.DISTRIBUTION_PATHS));
+        assertThat(Arrays.asList(paths), CoreMatchers.hasItems(PATH1));
+    }
+    
+    @Test
+    public void testFromEvent() {
+        Event osgiEvent = event.toEvent(DistributionEventTopics.AGENT_PACKAGE_CREATED);
+        DistributionEvent event2 = DistributionEvent.fromEvent(osgiEvent);
+        assertThat(event2.getPackageId(), equalTo(PKG_ID));
+        assertThat(event2.getComponentKind(), equalTo(KIND));
+        assertThat(event2.getComponentName(), equalTo(NAME));
+        assertThat(event2.getDistType(), equalTo(DIST_TYPE));
+        String[] paths = event2.getDistPaths();
+        assertThat(Arrays.asList(paths), CoreMatchers.hasItems(PATH1));
+    }
+
+}


### PR DESCRIPTION
In general,
- Improvement aims at adding the queue item creation time, essentially when the the item was creation for the first time, and enqueue into the queue.
- The purpose to get this detail is to be able to capture metrics at the consumer level. The consumers could have an event handler, which can capture the duration which turns out to be (NOW MINUS queue item creation time thrown in the distribution event package); NOW being the current time in the event handler (consumer).