### PR TITLE
SLING-9389: Distribution Event Properties enhanced for holding queue item creation time stamp

### DIFF
--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventProperties.java
@@ -51,4 +51,9 @@ public interface DistributionEventProperties {
      * Package id
      */
     String DISTRIBUTION_PACKAGE_ID = "distribution.package.id";
+
+    /**
+     * property containing the time when an item was created and enqueued for distribution
+     */
+    String DISTRIBUTION_ENQUEUE_TIMESTAMP = "distribution.enqueue.timestamp";
 }


### PR DESCRIPTION
In general,

- Improvement aims at adding the queue item creation time, essentially when the the item was creation for the first time, and enqueue into the queue.
- The purpose to get this detail is to be able to capture metrics at the consumer level. The consumers could have an event handler, which can capture the duration which turns out to be (NOW MINUS queue item creation time thrown in the distribution event package); NOW being the current time in the event handler (consumer).


@tmaret , @cschneider , kindly review. 

@actinium15 , kindly review this PR - its identical to  https://github.com/apache/sling-org-apache-sling-distribution-api/pull/2. I had to raise this new one to resolve some merge conflicts/issues.