### PR TITLE
SLING-10384: Execute actions before sending "o/a/s/d/i/package/import…

### DIFF
--- a/src/main/java/org/apache/sling/distribution/ImportPostProcessException.java
+++ b/src/main/java/org/apache/sling/distribution/ImportPostProcessException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution;
+
+/**
+ * Exception thrown by the Import post processor implementations
+ */
+public class ImportPostProcessException extends Exception {
+
+    public ImportPostProcessException(String message) {
+        super(message);
+    }
+
+    public ImportPostProcessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ImportPostProcessException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/apache/sling/distribution/ImportPostProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/ImportPostProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution;
+
+import java.util.Map;
+
+/**
+ * Executes any operations post import of distribution content
+ */
+public interface ImportPostProcessor {
+    /**
+     * Process any operations after import of content.
+     * 
+     * @param props properties defining the content imported
+     */
+    void process(Map<String, Object> props) throws ImportPostProcessException;
+}

--- a/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
+++ b/src/main/java/org/apache/sling/distribution/event/DistributionEventTopics.java
@@ -53,12 +53,6 @@ public interface DistributionEventTopics {
     String AGENT_PACKAGE_DROPPED = EVENT_BASE + "/agent/package/dropped";
 
     /**
-     * Event raised when a content package has already been committed to the
-     * repository, but before the {#link IMPORTER_PACKAGE_IMPORTED} event is sent.
-     */
-    String IMPORTER_PACKAGE_COMMITTED = EVENT_BASE + "/importer/package/committed";
-
-    /**
      * Event raised after successfully importing a content package.
      */
     String IMPORTER_PACKAGE_IMPORTED = EVENT_BASE + "/importer/package/imported";


### PR DESCRIPTION
…ed" event

- Add an interface and exception to act as import post processor